### PR TITLE
Fix Teams Component Rendering

### DIFF
--- a/octofit-tracker/frontend/src/components/Teams.js
+++ b/octofit-tracker/frontend/src/components/Teams.js
@@ -24,7 +24,13 @@ function Teams() {
           {teams.map(team => (
             <tr key={team._id}>
               <td>{team.name}</td>
-              <td>{team.members}</td>
+              <td>
+                <ul>
+                  {team.members.map(member => (
+                    <li key={member._id}>{member.username}</li>
+                  ))}
+                </ul>
+              </td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
This PR fixes the issue in the Teams component where members were not displayed correctly. Members are now rendered as a list.